### PR TITLE
fix : sass-loader option

### DIFF
--- a/webpack.config.script.js
+++ b/webpack.config.script.js
@@ -3,7 +3,6 @@ import path from "path";
 import { fileURLToPath } from "url";
 import webpack from "webpack";
 import HtmlWebpackPlugin from "html-webpack-plugin";
-import { NodePackageImporter } from "sass";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -41,11 +40,6 @@ export default (env, argv) => {
             },
             {
               loader: "sass-loader",
-              options: {
-                sassOptions: {
-                  pkgImporter: new NodePackageImporter(),
-                },
-              },
             },
           ],
         },


### PR DESCRIPTION
パッケージインポーターはデフォルトで読み込まれているので個別の指定は不要。冗長なので項目ごと削除